### PR TITLE
[FIX] call clean method raise ordinal cant be null.

### DIFF
--- a/formly/models.py
+++ b/formly/models.py
@@ -211,7 +211,7 @@ class Field(models.Model):
     
     survey = models.ForeignKey(Survey, related_name="fields")  # Denorm
     page = models.ForeignKey(Page, null=True, blank=True, related_name="fields")
-    label = models.CharField(max_length=100)
+    label = models.CharField(max_length=255)
     field_type = models.IntegerField(choices=FIELD_TYPE_CHOICES)
     help_text = models.CharField(max_length=255, blank=True)
     ordinal = models.IntegerField()


### PR DESCRIPTION
I configure a site with formly, calling full_clean when add a field raise ordinal field cant be null.

I delete the call and works fine.

Check it ! 
