### PR TITLE
Provide default value for required field

### DIFF
--- a/formly/models.py
+++ b/formly/models.py
@@ -216,7 +216,7 @@ class Field(models.Model):
     maximum_choices = models.IntegerField(null=True, blank=True)
     # Should this be moved to a separate Constraint model that can also
     # represent cross field constraints
-    required = models.BooleanField()
+    required = models.BooleanField(default=False)
 
     # def clean(self):
     #     super(Field, self).clean()


### PR DESCRIPTION
Beginning in Django 1.6, BooleanField’s default value changed to None
from False:

https://docs.djangoproject.com/en/dev/releases/1.6/#booleanfield-no-long
er-defaults-to-false

Explicitly set the default of the required field to False to avoid
integrity errors when saving a new instance.