### PR TITLE
Fix django-jsonfield version in installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -4,7 +4,7 @@ Installation
 ============
 
 * Requirements:
- * django-jsonfield==0.8.10
+ * django-jsonfield==0.9.13
 
 * Optional Requirements (to use the built in templates):
  * pinax-theme-bootstrap (not required if you use different block names)


### PR DESCRIPTION
The required version in `setup.py` is 0.9.13, but the installation docs still mention 0.8.10.