### PR TITLE
add `fieldtype` to widget.attrs for presentation

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,12 @@
 ChangeLog
 =========
 
+0.9.1
+-----
+
+- add `fieldtype` to PageForm field widget.attrs
+
+
 0.9
 ---
 

--- a/formly/forms/run.py
+++ b/formly/forms/run.py
@@ -46,6 +46,8 @@ class PageForm(FieldResultMixin, forms.Form):
         super(PageForm, self).__init__(*args, **kwargs)
         for field in self.page.fields.all():
             self.fields[field.name] = field.form_field()
+            # Save field_type in widget attrs so presentation can adjust if needed
+            self.fields[field.name].widget.attrs["fieldtype"] = field.field_type
             targets = field.choices.filter(target__isnull=False)
             if targets.count() > 0:
                 self.fields[field.name].widget.attrs["data-reveal"] = ",".join([

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description="a dynamic form generator",
     name="formly",
     long_description=read("README.rst"),
-    version="0.9",
+    version="0.9.1",
     url="https://github.com/eldarion/formly",
     license="BSD",
     packages=find_packages(),


### PR DESCRIPTION
Was trying to determine field type (see formly.models.Field.FIELD_TYPE_CHOICES) **in the template** in order to present Likert-style fields differently than normal (Bootstrap) radio fields. Didn't see anything, so added `fieldtype` to `widget.attrs`, but not sure if this is copacetic.

