### PR TITLE
Add likert-style presentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 docs/_build
 formly.egg-info
 dist
+*.pyc
+.coverage
+.tox
+.python-version
+.eggs/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ python:
   - "3.5"
 env:
   - DJANGO=1.8
+  - DJANGO=1.9
   - DJANGO=1.10
-  - DJANGO=master
 matrix:
   exclude:
 install:

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,12 @@
 ChangeLog
 =========
 
+0.9.1
+-----
+
+- add `fieldtype` to PageForm field widget.attrs
+
+
 0.9
 ---
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,10 +3,10 @@
 ChangeLog
 =========
 
-0.9.1
+0.10
 -----
 
-- add `fieldtype` to PageForm field widget.attrs
+- add Likert-style field widget and presentation
 
 
 0.9

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -35,7 +35,7 @@ radio choices
 -------------
 
 The ``radio choices`` field type is a ``django.forms.ChoiceField`` with a
-``django.forms.RadioSelect`` widget, populated with choices as specified at
+``django.forms.RadioSelect`` widget, populated with choices specified at
 design time.
 
 
@@ -44,7 +44,7 @@ dropdown field
 
 The ``dropdown field`` is a select field generated from a
 ``django.forms.ChoiceField`` with a ``django.forms.Select`` widget, populated
-with choices as specified at design time.
+with choices specified at design time.
 
 
 checkbox field
@@ -52,7 +52,7 @@ checkbox field
 
 The ``checkbox field`` is a field generated from a
 ``django.forms.MultipleChoiceField`` with a ``django.forms.CheckboxInput`` widget,
-populated with choices as specified at design time. This field allows for
+populated with choices specified at design time. This field allows for
 multiple selections.
 
 
@@ -75,3 +75,58 @@ boolean field
 
 The ``boolean field`` renders and processes input using
 ``django.forms.BooleanField``.
+
+
+multiple text field
+-------------------
+
+The ``multiple text`` field type presents a number of single line fields.
+The number of fields is specified at design time.
+
+
+likert scale field
+------------------
+
+The ``likert scale`` field type is a ``django.forms.ChoiceField``,
+populated with choices specified at design time.
+Presentation uses formly/templates/bootstrapform/field.html and sets
+``<ul class="likert-question">`` for CSS design. Here is sample CSS
+which presents a Likert field in familiar horizontal layout:
+
+    form .likert-question {
+      list-style:none;
+      width:100%;
+      margin:0;
+      padding:0 0 35px;
+      display:block;
+      border-bottom:2px solid #efefef;
+    }
+    form .likert-question:last-of-type {
+      border-bottom:0;
+    }
+    form .likert-question:before {
+      content: '';
+      position:relative;
+      top:13px;
+      left:13%;
+      display:block;
+      background-color:#dfdfdf;
+      height:4px;
+      width:75%;
+    }
+    form .likert-question li {
+      display:inline-block;
+      width:19%;
+      text-align:center;
+      vertical-align: top;
+    }
+    form .likert-question li input[type=radio] {
+      display:block;
+      position:relative;
+      top:0;
+      left:50%;
+      margin-left:-6px;
+    }
+    form .likert-question li label {
+      width:100%;
+    }

--- a/docs/fields.rst
+++ b/docs/fields.rst
@@ -88,10 +88,16 @@ likert scale field
 ------------------
 
 The ``likert scale`` field type is a ``django.forms.ChoiceField``,
-populated with choices specified at design time.
-Presentation uses formly/templates/bootstrapform/field.html and sets
-``<ul class="likert-question">`` for CSS design. Here is sample CSS
-which presents a Likert field in familiar horizontal layout:
+populated with choices specified at design time. The field template
+``formly/templates/bootstrapform/field.html`` emits:
+
+    <ul class="likert-question">
+        {{ field }}
+    </ul>
+
+for hooking in CSS design. The following sample CSS presents a Likert field
+in familiar horizontal layout. You should add this (or similar)
+CSS to your project to get Likert-scale presentation.
 
     form .likert-question {
       list-style:none;

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -133,3 +133,12 @@ A template for displaying the results of a given survey.
 
 This template is rendered for the end user to complete a particular survey, it is always
 rendered with the appropriate page for the user.
+
+
+``formly/bootstrapform/field.html``
+------------------------
+
+:Context: ``field``
+
+This modified ``django-bootstrap-form`` template renders the various field types,
+including special handling for Likert fields.

--- a/formly/forms/run.py
+++ b/formly/forms/run.py
@@ -46,8 +46,6 @@ class PageForm(FieldResultMixin, forms.Form):
         super(PageForm, self).__init__(*args, **kwargs)
         for field in self.page.fields.all():
             self.fields[field.name] = field.form_field()
-            # Save field_type in widget attrs so presentation can adjust if needed
-            self.fields[field.name].widget.attrs["fieldtype"] = field.field_type
             targets = field.choices.filter(target__isnull=False)
             if targets.count() > 0:
                 self.fields[field.name].widget.attrs["data-reveal"] = ",".join([

--- a/formly/forms/run.py
+++ b/formly/forms/run.py
@@ -46,6 +46,8 @@ class PageForm(FieldResultMixin, forms.Form):
         super(PageForm, self).__init__(*args, **kwargs)
         for field in self.page.fields.all():
             self.fields[field.name] = field.form_field()
+            # Save field_type in widget attrs so presentation can adjust if needed
+            self.fields[field.name].widget.attrs["fieldtype"] = field.field_type
             targets = field.choices.filter(target__isnull=False)
             if targets.count() > 0:
                 self.fields[field.name].widget.attrs["data-reveal"] = ",".join([

--- a/formly/forms/widgets.py
+++ b/formly/forms/widgets.py
@@ -2,4 +2,8 @@ from django.forms.widgets import RadioSelect
 
 
 class LikertSelect(RadioSelect):
+    """
+    This class differentiates Likert-scale radio selects
+    from "normal" radio selects for presentation purposes.
+    """
     pass

--- a/formly/forms/widgets.py
+++ b/formly/forms/widgets.py
@@ -1,0 +1,5 @@
+from django.forms.widgets import RadioSelect
+
+
+class LikertSelect(RadioSelect):
+    pass

--- a/formly/models.py
+++ b/formly/models.py
@@ -341,11 +341,11 @@ class Field(models.Model):
         else:
             choices = [(x.pk, x.label) for x in self.choices.all()]
 
-        field_class, field_kwargs = self._set_field_class(choices)
+        field_class, field_kwargs = self._get_field_class(choices)
         field = field_class(**field_kwargs)
         return field
 
-    def _set_field_class(self, choices):
+    def _get_field_class(self, choices):
         """
         Set field_class and field kwargs based on field type
         """

--- a/formly/models.py
+++ b/formly/models.py
@@ -341,14 +341,22 @@ class Field(models.Model):
         else:
             choices = [(x.pk, x.label) for x in self.choices.all()]
 
+        field_class, field_kwargs = self._set_field_class(choices)
+        field = field_class(**field_kwargs)
+        return field
+
+    def _set_field_class(self, choices):
+        """
+        Set field_class and field kwargs based on field type
+        """
+        field_class = forms.CharField
         kwargs = dict(
             label=self.label,
             help_text=self.help_text,
             required=self.required
         )
-        field_class = forms.CharField
-
         if self.field_type == Field.TEXT_AREA:
+            field_class = forms.CharField
             kwargs.update({"widget": forms.Textarea()})
         elif self.field_type in [Field.RADIO_CHOICES, Field.LIKERT_FIELD]:
             field_class = forms.ChoiceField
@@ -374,9 +382,7 @@ class Field(models.Model):
                 "fields_length": self.expected_answers,
                 "widget": MultiTextWidget(widgets_length=self.expected_answers),
             })
-
-        field = field_class(**kwargs)
-        return field
+        return field_class, kwargs
 
 
 @python_2_unicode_compatible

--- a/formly/models.py
+++ b/formly/models.py
@@ -14,6 +14,7 @@ from django.contrib.auth.models import User
 from jsonfield import JSONField
 
 from .forms import MultipleTextField, MultiTextWidget
+from .forms.widgets import LikertSelect
 
 
 @python_2_unicode_compatible
@@ -351,7 +352,10 @@ class Field(models.Model):
             kwargs.update({"widget": forms.Textarea()})
         elif self.field_type in [Field.RADIO_CHOICES, Field.LIKERT_FIELD]:
             field_class = forms.ChoiceField
-            kwargs.update({"widget": forms.RadioSelect(), "choices": choices})
+            if self.field_type == Field.LIKERT_FIELD:
+                kwargs.update({"widget": LikertSelect(), "choices": choices})
+            else:
+                kwargs.update({"widget": forms.RadioSelect(), "choices": choices})
         elif self.field_type == Field.DATE_FIELD:
             field_class = forms.DateField
         elif self.field_type == Field.SELECT_FIELD:

--- a/formly/templates/bootstrapform/field.html
+++ b/formly/templates/bootstrapform/field.html
@@ -1,0 +1,86 @@
+{% load bootstrap %}
+{% load formly %}
+
+<div class="form-group{% if field.errors %} has-error{% endif %}">
+    {% if field|is_checkbox %}
+        <div class="{{ classes.single_value }}">
+            <div class="checkbox">
+                {% if field.auto_id %}
+                    <label {% if field.field.required and form.required_css_class %}class="{{ form.required_css_class }}"{% endif %}>
+                        {{ field }} <span>{{ field.label }}</span>
+                    </label>
+                {% endif %}
+                {% for error in field.errors %}
+                    <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
+                {% endfor %}
+
+                {% if field.help_text %}
+                    <p class="help-block">
+                        {{ field.help_text|safe }}
+                    </p>
+                {% endif %}
+            </div>
+        </div>
+    {% elif field|is_radio %}
+        {% if field.auto_id %}
+            <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}">{{ field.label }}</label>
+        {% endif %}
+        <div class="{{ classes.value }}">
+            {% for choice in field %}
+                <div class="radio">
+                    <label>
+                        {{ choice.tag }}
+                        {{ choice.choice_label }}
+                    </label>
+                </div>
+            {% endfor %}
+
+            {% for error in field.errors %}
+                <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
+            {% endfor %}
+
+            {% if field.help_text %}
+            <p class="help-block">
+                {{ field.help_text|safe }}
+            </p>
+            {% endif %}
+        </div>
+    {% elif field|is_likert %}
+        {% if field.auto_id %}
+            <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}">{{ field.label }}</label>
+        {% endif %}
+        <div class="{{ classes.value }}">
+            <ul class="likert-question">
+                {{ field }}
+            </ul>
+
+            {% for error in field.errors %}
+                <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
+            {% endfor %}
+
+            {% if field.help_text %}
+            <p class="help-block">
+                {{ field.help_text|safe }}
+            </p>
+            {% endif %}
+        </div>
+    {% else %}
+        {% if field.auto_id %}
+            <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}" for="{{ field.auto_id }}">{{ field.label }}</label>
+        {% endif %}
+
+        <div class="{{ classes.value }} {% if field|is_multiple_checkbox %}multiple-checkbox{% endif %}">
+            {{ field }}
+
+            {% for error in field.errors %}
+                <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
+                {% endfor %}
+
+            {% if field.help_text %}
+                <p class="help-block">
+                    {{ field.help_text|safe }}
+                </p>
+            {% endif %}
+        </div>
+    {% endif %}
+</div>

--- a/formly/templates/bootstrapform/field.html
+++ b/formly/templates/bootstrapform/field.html
@@ -21,6 +21,25 @@
                 {% endif %}
             </div>
         </div>
+    {% elif field|is_likert %}  {# Likert-style fields inherit from RadioSelect, must be tested before is_radio #}
+        {% if field.auto_id %}
+            <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}">{{ field.label }}</label>
+        {% endif %}
+        <div class="{{ classes.value }}">
+            <ul class="likert-question">
+                {{ field }}
+            </ul>
+
+            {% for error in field.errors %}
+                <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
+            {% endfor %}
+
+            {% if field.help_text %}
+            <p class="help-block">
+                {{ field.help_text|safe }}
+            </p>
+            {% endif %}
+        </div>
     {% elif field|is_radio %}
         {% if field.auto_id %}
             <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}">{{ field.label }}</label>
@@ -34,25 +53,6 @@
                     </label>
                 </div>
             {% endfor %}
-
-            {% for error in field.errors %}
-                <span class="help-block {{ form.error_css_class }}">{{ error }}</span>
-            {% endfor %}
-
-            {% if field.help_text %}
-            <p class="help-block">
-                {{ field.help_text|safe }}
-            </p>
-            {% endif %}
-        </div>
-    {% elif field|is_likert %}
-        {% if field.auto_id %}
-            <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}">{{ field.label }}</label>
-        {% endif %}
-        <div class="{{ classes.value }}">
-            <ul class="likert-question">
-                {{ field }}
-            </ul>
 
             {% for error in field.errors %}
                 <span class="help-block {{ form.error_css_class }}">{{ error }}</span>

--- a/formly/templatetags/formly.py
+++ b/formly/templatetags/formly.py
@@ -1,0 +1,10 @@
+from django import template
+
+from ..forms.widgets import LikertSelect
+
+register = template.Library()
+
+
+@register.filter
+def is_likert(field):
+    return isinstance(field.field.widget, LikertSelect)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description="a dynamic form generator",
     name="formly",
     long_description=read("README.rst"),
-    version="0.9.1",
+    version="0.10",
     url="https://github.com/eldarion/formly",
     license="BSD",
     packages=find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description="a dynamic form generator",
     name="formly",
     long_description=read("README.rst"),
-    version="0.9",
+    version="0.9.1",
     url="https://github.com/eldarion/formly",
     license="BSD",
     packages=find_packages(),

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,3 @@ setenv =
 commands =
     flake8 formly
     coverage run setup.py test
-    {py35}-1.10: python checkmigrations.py

--- a/tox.ini
+++ b/tox.ini
@@ -6,17 +6,17 @@ exclude = formly/migrations/*,docs/*
 
 [tox]
 envlist =
-    py27-{1.8,1.10,master},
-    py34-{1.8,1.10,master},
-    py35-{1.8,1.10,master}
+    py27-{1.8,1.9,1.10},
+    py34-{1.8,1.9,1.10},
+    py35-{1.8,1.9,1.10}
 
 [testenv]
 deps =
     coverage == 4.0.2
     flake8 == 2.5.0
     1.8: Django>=1.8,<1.9
+    1.9: Django>=1.9,<1.10
     1.10: Django>=1.10,<1.11
-    master: https://github.com/django/django/tarball/master
 usedevelop = True
 setenv =
    LANG=en_US.UTF-8


### PR DESCRIPTION
Add LikertSelect, inheriting from RadioSelect with no changes. This widget class exists to distinguish from standard RadioSelect widgets.
Add `is_likert` templatetag.
Add `field.html` based on django-bootstrap-form file, with support for Likert-style fields.
Expand .gitignore.
Add Django v1.9 to test matrix, remove Django dev master.