### PR TITLE
Fix Field.form_field() exception

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,11 @@
 ChangeLog
 =========
 
+0.10.1
+------
+
+- fix Field.form_field() bug when Likert field has no choices
+
 0.10
 -----
 

--- a/formly/models.py
+++ b/formly/models.py
@@ -337,7 +337,10 @@ class Field(models.Model):
 
     def form_field(self):
         if self.field_type == Field.LIKERT_FIELD:
-            choices = [(x.pk, x.label) for x in self.scale.choices.all().order_by("score")]
+            if self.scale:
+                choices = [(x.pk, x.label) for x in self.scale.choices.all().order_by("score")]
+            else:
+                choices = []
         else:
             choices = [(x.pk, x.label) for x in self.choices.all()]
 

--- a/formly/tests/tests.py
+++ b/formly/tests/tests.py
@@ -1,7 +1,31 @@
+from django.contrib.auth.models import User
 from django.test import TestCase
+
+from ..models import (
+    Field,
+    Survey,
+)
 
 
 class Tests(TestCase):
 
     def setUp(self):
-        pass
+        self.user = User.objects.create_user("foo", password="bar")
+
+    def test_likert_field_missing_scale(self):
+        """
+        Ensure Likert field missing choices still produces form field.
+        """
+        survey = Survey(
+            name="likert test",
+            creator=self.user,
+        )
+        # create Likert field without associated LikertScale
+        field = Field(
+            survey=survey,
+            label="likert field",
+            field_type=Field.LIKERT_FIELD,
+        )
+        self.assertFalse(field.choices.all())
+        # Ensure no exception when field has no choices
+        self.assertTrue(field.form_field())

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     description="a dynamic form generator",
     name="formly",
     long_description=read("README.rst"),
-    version="0.10",
+    version="0.10.1",
     url="https://github.com/eldarion/formly",
     license="BSD",
     packages=find_packages(),


### PR DESCRIPTION
Don't raise exception when Likert field has no choices.

Bumped version to "0.10.1" as this is a bug fix with test.
Would appreciate a new PyPi formly release if approved, thanks!